### PR TITLE
Fixed a bug where the last canvas was being exported for all canvases.

### DIFF
--- a/src/omnigraffle_export/__init__.py
+++ b/src/omnigraffle_export/__init__.py
@@ -78,7 +78,7 @@ class OmniGraffleSchema(object):
                          (canvasname, self.schemafile))
             return False
 
-        self.og.set(win.canvas, to=c)
+        self.og.set(win.canvas, to=canvas)
 
         self.doc.save(as_=OmniGraffleSchema.EXPORT_FORMATS[format], in_=file)
 


### PR DESCRIPTION
That's it. You were using the variable "c", which was being set in a loop, so after the loop it was always set to the last canvas.
