### PR TITLE
Get omnigraffle-export to accept a multi-file omnigraffle project

### DIFF
--- a/omnigraffle_export.py
+++ b/omnigraffle_export.py
@@ -32,8 +32,9 @@ class OmniGraffleSchema(object):
         @param verbose
         """
 
-        schemafile = os.path.abspath(schemafile)  
-        if not os.path.isfile(schemafile):
+        schemafile = os.path.abspath(schemafile)
+        if not os.path.isfile(schemafile) and \
+                not os.path.isfile(os.path.join(schemafile, "data.plist"):
             raise ValueError('File: %s does not exists' % schemafile)
 
         # options


### PR DESCRIPTION
After adding a few pdf's to a graph, my graffle project was changed by omnigraffle to this

> midgard (18:57) >ls -l alpha-beta-in-gk.graffle/
> total 376
> -rw-r--r--  1 sjl  staff  173536 Apr  7 18:31 data.plist
> -rw-r--r--  1 sjl  staff    7181 Apr  7 18:31 image1.pdf
> -rw-r--r--  1 sjl  staff    7242 Apr  7 18:31 image2.pdf

This made omnigraffle-export to throw an exception, as it only accepted a file.  I changed the code to recognize also this kind of multi-file repository.

The first commit is a cosmetic change related to long lines (a coding style I'm used to and which is used in my places of work).
