### PR TITLE
Fix missing parentheses and sandbox checking

### DIFF
--- a/omnigraffle_export/omnigraffle.py
+++ b/omnigraffle_export/omnigraffle.py
@@ -11,7 +11,7 @@ class OmniGraffleSchema(object):
         "eps": "EPS",
         "pdf": "PDF",
         "png": "PNG",
-        
+
         # FIXME
         # "svg": "SVG",
         # "tiff" : "TIFF",
@@ -30,8 +30,8 @@ class OmniGraffleSchema(object):
 
     def sandboxed(self):
         # real check using '/usr/bin/codesign --display --entitlements - /Applications/OmniGraffle.app'
-        return self.og.version()[0] == '6' and os.path.exists(OmniGraffle.SANDBOXED_DIR_6)
-        
+        return self.og.version()[0] == '6' and os.path.exists(os.path.expanduser(OmniGraffle.SANDBOXED_DIR_6))
+
     def get_canvas_list(self):
         """
         Returns a list of names of all the canvases in the document


### PR DESCRIPTION
As far as I know, if the Python function parentheses are omitted, the statement will return function reference, which is always to be True.
